### PR TITLE
Update docraptor.yaml

### DIFF
--- a/docraptor.yaml
+++ b/docraptor.yaml
@@ -142,7 +142,6 @@ definitions:
     required:
       - name
       - document_type
-      - document_content
     properties:
       name:
         type: string


### PR DESCRIPTION
`document_content` as a singular required field vs. one of either content or url is not longer okay as of swagger 2.2. This has to be removed because validations are being added to the gen'ed code that would prevent using urls to make docs