### PR TITLE
Tag support for .swagger-revision

### DIFF
--- a/script/swagger
+++ b/script/swagger
@@ -14,6 +14,10 @@ fi
 
 (
   cd swagger-codegen
+  if [[ "${#SWAGGER_CODGEN_REVISION}" -lt 40 ]]; then
+    # resolve git tags / branch names
+    SWAGGER_CODGEN_REVISION=$(git show "$SWAGGER_CODGEN_REVISION" --format="%H")
+  fi
   if [[ $(cat .git/HEAD) != "$SWAGGER_CODGEN_REVISION" ]]; then
     git fetch
     git checkout "$SWAGGER_CODGEN_REVISION"


### PR DESCRIPTION
This branch allows the `.swagger-revision` file to contain references tags/branches/etc. Simplifying selection of a release to something like `v2.1.3` instead of a full commit hash.