### PR TITLE
Name is no longer a required field

### DIFF
--- a/docraptor.yaml
+++ b/docraptor.yaml
@@ -140,7 +140,6 @@ definitions:
   Doc:
     type: object
     required:
-      - name
       - document_type
       - document_content
     properties:


### PR DESCRIPTION
Update the API definition to reflect that as of 2016-10-18, the name field is no longer required by the server.